### PR TITLE
Fixed a bug that prevented the last item from getting imported

### DIFF
--- a/Backend/OtbData.cs
+++ b/Backend/OtbData.cs
@@ -429,8 +429,8 @@ namespace Backend
 
             if (createdCount != 0)
             {
-                Trace.WriteLine($"Created {createdCount} new items, server IDs {prevLastServerId + 1} - {serverIdCursor - 1}");
-                LastServerId = serverIdCursor - 1;
+                Trace.WriteLine($"Created {createdCount} new items, server IDs {prevLastServerId + 1} - {serverIdCursor}");
+                LastServerId = serverIdCursor;
             }
             else
             {


### PR DESCRIPTION
Last item doesn't get created when clicking "create missing client ids", this commit fixes that